### PR TITLE
NGX-729: Set /etc/redis/redis.conf as redis default config path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for inmotion.redis
 
-redis_conf: /etc/redis.conf
+redis_conf: /etc/redis/redis.conf
 redis_conf_bind: 127.0.0.1
 redis_conf_daemonize: "yes"
 redis_conf_logfile: /var/log/redis/redis.log

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,4 @@
 ---
-redis_conf: /etc/redis/redis.conf
 redis_conf_pidfile: /var/run/redis/redis-server.pid
 redis_packages:
   - redis-server


### PR DESCRIPTION
- The config path used by redis package installed from remi repo is /etc/redis/redis.conf.  When installed via epel it is /etc/redis.conf.  Since the playbook enforces installation via remi repo, we should set /etc/redis/redis.conf as the default config location.