### PR TITLE
NGX-784: Configure redis port

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Available variables are listed below with their default values (you can also see
 | redis_conf_maxmemory | The maximum memory to be used by Redis.
 | redis_conf_maxmemory_policy | The memory handling policy to use.
 | redis_conf_pidfile | The location of the Redis pidfile.
+| redis_conf_port | Accept connections on the specified port.
 | redis_conf_requirepass | Whether a password is required to log in to Redis.
 | redis_conf_supervised | The init system Redis should target. <br><br>Default: `systemd`
 | redis_conf_timeout | The maximum time a client connection to Redis should live.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ redis_conf_logfile: /var/log/redis/redis.log
 redis_conf_maxmemory: 1G
 redis_conf_maxmemory_policy: allkeys-lru
 redis_conf_pidfile: /var/run/redis/redis.pid
+redis_conf_port: 6379
 redis_conf_requirepass: false
 redis_conf_supervised: systemd
 redis_conf_timeout: 60

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -9,11 +9,7 @@ bind {{ redis_conf_bind }}
 protected-mode yes
 {% endif %}
 
-{% if redis_conf_unixsocket %}
-port 0
-{% else %}
-port 6379
-{% endif %}
+port {{ redis_conf_port }}
 
 {% if redis_conf_unixsocket %}
 unixsocket {{ redis_conf_unixsocket_location }}


### PR DESCRIPTION
This change allows the user to listen on unixsocket and port simultaneously.  Setting the port to 0 disables listening of redis on tcp port.